### PR TITLE
Update index.ts

### DIFF
--- a/src/@ionic-native/plugins/document-picker/index.ts
+++ b/src/@ionic-native/plugins/document-picker/index.ts
@@ -24,7 +24,7 @@ import { Cordova, Plugin, IonicNativePlugin } from '@ionic-native/core';
  */
 @Plugin({
   pluginName: 'IOSDocumentPicker',
-  plugin: 'cordova-plugin-documentpicker.DocumentPicker',
+  plugin: 'cordova-plugin-documentpicker',
   pluginRef: 'DocumentPicker',
   repo: 'https://github.com/iampossible/Cordova-DocPicker',
   platforms: ['iOS']


### PR DESCRIPTION
Adding the plugin via command given at ionic native documentation gives an error as below. 

> cordova plugin add cordova-plugin-documentpicker.DocumentPicker --save

(node:1899) UnhandledPromiseRejectionWarning: Error: npm: Command failed with exit code 1 Error output:
npm ERR! code E404
npm ERR! 404 'cordova-plugin-documentpicker.DocumentPicker' is not in the npm registry.
npm ERR! 404 name can no longer contain capital letters
npm ERR! 404
npm ERR! 404  'cordova-plugin-documentpicker.DocumentPicker@latest' is not in the npm registry.
npm ERR! 404 Your package name is not valid, because
npm ERR! 404  1. name can no longer contain capital letters
npm ERR! 404
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

To fix it the command should be as below:

> ionic cordova plugin add cordova-plugin-documentpicker

I have added the fix in the file index.ts.